### PR TITLE
Search engines URL rewriting to force safe mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
-# 09/01/2014
+# 18/03/2014
+# Version 3.90  Utilisation de squid + squidguard pour ré-écrire les URL des moteurs de recherche afin de forcer les modes "safe".
+#               Impose de configurer le proxy localhost:3128 pour les comptes non privilégiés.
 # Version 3.84  Abendont des scripte a l'ouverture de session au profit de règles iptables dedier au utilisateur filtrée.
 # Version 3.83 	Correctif de bugs, notament celui qui pouvais suprimer trops de paquet a la desinstallation (en mode manuel)
 #				Compatibilitée avec mageia 3 et 4 

--- a/CTparental.sh
+++ b/CTparental.sh
@@ -995,11 +995,20 @@ install () {
       $ENDNSMASQ
       $ENNWMANAGER
       $ENIPTABLESSAVE
-
-
-      
+      setproxyenv
 }
 
+
+setproxyenv () {
+  unsetproxyenv
+  echo "#CTparentalBEGIN" >>/etc/environment
+  cat "$DIR_CONF/localproxy.env" >>/etc/environment
+  echo "#CTparentalEND" >>/etc/environment
+}
+
+unsetproxyenv () {
+  sed -i '/CTparentalBEGIN/,/CTparentalEND/d' /etc/environment
+}
 
 updatelistgctoff () {
 	## on ajoutes tous les utilisateurs manquant dans la liste
@@ -1045,6 +1054,7 @@ desactivegourpectoff () {
 }
 
 uninstall () {
+   unsetproxyenv
    desactivegourpectoff
    rm -f /etc/cron.d/CTparental*
    $DNSMASQrestart

--- a/CTparental.sh
+++ b/CTparental.sh
@@ -782,7 +782,7 @@ cp -rf CTadmin/* $DIRadminHTML/
 	clear
 	echo "Entrer le mot de passe de $loginhttp :"
 	while (true); do
-		 read password
+		 read -s password
 		 case $password in
 			 * )
 			 echo "password: $password" >> /root/passwordCTadmin

--- a/dist.conf
+++ b/dist.conf
@@ -25,6 +25,8 @@
 #NWMANAGERstart="systemctl start NetworkManager "	# mageia 3/4 , fedora 19/20
 #NWMANAGERrestart="systemctl restart NetworkManager "	# mageia 3/4 , fedora 19/20
 #IPTABLESsave="service iptables save"			# Red Had , # fedora 19/20
+#SQUIDrestart="service squid3 restart"
+#SQUIDstop="service squid3 stop"
 ##################################################
 
 ####### Activation des services au demarage #####
@@ -33,6 +35,8 @@
 #ENDNSMASQ="systemctl enable dnsmasq "			# mageia 3/4 , fedora 19/20
 #ENNWMANAGER="systemctl enable NetworkManager "	# mageia 3/4 , fedora 19/20
 #ENIPTABLESSAVE="systemctl enable iptables.service"			# fedora 19/20
+#ENSQUID="systemctl enable squid3 "				# mageia 3/4 , fedora 19/20
+#DISSQUID="systemctl enable squid3 "				# mageia 3/4 , fedora 19/20
 #################################################
 
 

--- a/google.conf
+++ b/google.conf
@@ -1,0 +1,2 @@
+address=/encrypted.google.com/127.0.0.10
+conf-file=/usr/local/share/CTparental/google-tld.conf

--- a/localproxy.env
+++ b/localproxy.env
@@ -1,0 +1,8 @@
+http_proxy=http://localhost:3128/
+https_proxy=http://localhost:3128/
+ftp_proxy=http://localhost:3128/
+no_proxy="localhost,127.0.0.1"
+HTTP_PROXY=http://localhost:3128/
+HTTPS_PROXY=http://localhost:3128/
+FTP_PROXY=http://localhost:3128/
+NO_PROXY="localhost,127.0.0.1"


### PR DESCRIPTION
Bonjour Guillaume,

Voici une proposition d'évolution qui correspond à ma configuration actuelle. Ça implémente l'utilisation de squid + squidguard pour la ré-écriture d'URL des moteurs de recherche afin de forcer le mode "safe". Pour google ça force également le "nosslsearch" qui pourrait permettre de contourner cette protection.

Le seul inconvénient est qu'il faut configurer l'utilisation du proxy localhost:3128 pour les utilisateurs non privilégiés. Sinon ils n'ont aucun accès internet. Je pense qu'une configuration du proxy à l'échelle du système conviendrait, mais je n'ai pas fait l'exercice.

C'est testé sur Debian/testing (jessie). Je n'ai pas d'autre distribution sous la main.